### PR TITLE
THRIFT-5369: Use MaxMessageSize to check container sizes

### DIFF
--- a/lib/go/thrift/binary_protocol.go
+++ b/lib/go/thrift/binary_protocol.go
@@ -322,8 +322,8 @@ func (p *TBinaryProtocol) ReadMapBegin() (kType, vType TType, size int, err erro
 		err = NewTProtocolException(e)
 		return
 	}
-	if size32 < 0 {
-		err = invalidDataLength
+	err = checkSizeForProtocol(size32)
+	if err != nil {
 		return
 	}
 	size = int(size32)
@@ -346,8 +346,8 @@ func (p *TBinaryProtocol) ReadListBegin() (elemType TType, size int, err error) 
 		err = NewTProtocolException(e)
 		return
 	}
-	if size32 < 0 {
-		err = invalidDataLength
+	err = checkSizeForProtocol(size32)
+	if err != nil {
 		return
 	}
 	size = int(size32)
@@ -371,8 +371,8 @@ func (p *TBinaryProtocol) ReadSetBegin() (elemType TType, size int, err error) {
 		err = NewTProtocolException(e)
 		return
 	}
-	if size32 < 0 {
-		err = invalidDataLength
+	err = checkSizeForProtocol(size32)
+	if err != nil {
 		return
 	}
 	size = int(size32)
@@ -430,8 +430,8 @@ func (p *TBinaryProtocol) ReadString() (value string, err error) {
 	if e != nil {
 		return "", e
 	}
-	if size < 0 {
-		err = invalidDataLength
+	err = checkSizeForProtocol(size)
+	if err != nil {
 		return
 	}
 

--- a/lib/go/thrift/compact_protocol.go
+++ b/lib/go/thrift/compact_protocol.go
@@ -433,8 +433,8 @@ func (p *TCompactProtocol) ReadMapBegin() (keyType TType, valueType TType, size 
 		err = NewTProtocolException(e)
 		return
 	}
-	if size32 < 0 {
-		err = invalidDataLength
+	err = checkSizeForProtocol(size32)
+	if err != nil {
 		return
 	}
 	size = int(size32)
@@ -469,11 +469,11 @@ func (p *TCompactProtocol) ReadListBegin() (elemType TType, size int, err error)
 			err = NewTProtocolException(e)
 			return
 		}
-		if size2 < 0 {
-			err = invalidDataLength
-			return
-		}
 		size = int(size2)
+	}
+	err = checkSizeForProtocol(size32)
+	if err != nil {
+		return
 	}
 	elemType, e := p.getTType(tCompactType(size_and_type))
 	if e != nil {

--- a/lib/go/thrift/configuration.go
+++ b/lib/go/thrift/configuration.go
@@ -1,0 +1,23 @@
+package thrift
+
+import "fmt"
+
+const (
+	DEFAULT_MAX_MESSAGE_SIZE = 100 * 1024 * 1024
+)
+
+func checkSizeForProtocol(size int32) error {
+	if size < 0 {
+		return NewTProtocolExceptionWithType(
+			NEGATIVE_SIZE,
+			fmt.Errorf("negative size: %d", size),
+		)
+	}
+	if size > DEFAULT_MAX_MESSAGE_SIZE {
+		return NewTProtocolExceptionWithType(
+			SIZE_LIMIT,
+			fmt.Errorf("size exceeded max allowed: %d", size),
+		)
+	}
+	return nil
+}

--- a/lib/go/thrift/json_protocol.go
+++ b/lib/go/thrift/json_protocol.go
@@ -310,9 +310,13 @@ func (p *TJSONProtocol) ReadMapBegin() (keyType TType, valueType TType, size int
 	}
 
 	// read size
-	iSize, e := p.ReadI64()
-	if e != nil {
-		return keyType, valueType, size, e
+	iSize, err := p.ReadI64()
+	if err != nil {
+		return keyType, valueType, size, err
+	}
+	err = checkSizeForProtocol(int32(iSize))
+	if err != nil {
+		return keyType, valueType, 0, err
 	}
 	size = int(iSize)
 
@@ -480,9 +484,16 @@ func (p *TJSONProtocol) ParseElemListBegin() (elemType TType, size int, e error)
 	if err != nil {
 		return elemType, size, err
 	}
-	nSize, err2 := p.ReadI64()
+	nSize, _, err := p.ParseI64()
+	if err != nil {
+		return elemType, 0, err
+	}
+	err = checkSizeForProtocol(int32(nSize))
+	if err != nil {
+		return elemType, 0, err
+	}
 	size = int(nSize)
-	return elemType, size, err2
+	return elemType, size, nil
 }
 
 func (p *TJSONProtocol) readElemListBegin() (elemType TType, size int, e error) {

--- a/lib/go/thrift/simple_json_protocol.go
+++ b/lib/go/thrift/simple_json_protocol.go
@@ -384,6 +384,13 @@ func (p *TSimpleJSONProtocol) ReadMapBegin() (keyType TType, valueType TType, si
 
 	// read size
 	iSize, err := p.ReadI64()
+	if err != nil {
+		return keyType, valueType, 0, err
+	}
+	err = checkSizeForProtocol(int32(size))
+	if err != nil {
+		return keyType, valueType, 0, err
+	}
 	size = int(iSize)
 	return keyType, valueType, size, err
 }
@@ -1040,9 +1047,16 @@ func (p *TSimpleJSONProtocol) ParseElemListBegin() (elemType TType, size int, e 
 	if err != nil {
 		return elemType, size, err
 	}
-	nSize, err2 := p.ReadI64()
+	nSize, _, err := p.ParseI64()
+	if err != nil {
+		return elemType, 0, err
+	}
+	err = checkSizeForProtocol(int32(nSize))
+	if err != nil {
+		return elemType, 0, err
+	}
 	size = int(nSize)
-	return elemType, size, err2
+	return elemType, size, nil
 }
 
 func (p *TSimpleJSONProtocol) ParseListEnd() error {


### PR DESCRIPTION
Client: go

<!-- Explain the changes in the pull request below: -->
  
Backport of THRIFT-5369 for thrift 0.9.3.x used by jaeger 1.17.x

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
